### PR TITLE
Renaming + editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,10 +14,6 @@ indent_size = 4
 [*.md]
 indent_style = space
 
-[package.json]
-indent_style = space
-indent_size = 2
-
 [COMMIT_EDITMSG]
 trim_trailing_whitespace = false
 max_line_length = 72

--- a/lib/build-bundler.js
+++ b/lib/build-bundler.js
@@ -1,7 +1,7 @@
 let path = require("path");
 let sass = require("node-sass");
 let fs = require("fs");
-let { generateFingerprint } = require("faucet-pipeline-cli/util");
+let { generateFingerprint } = require("faucet-pipeline-util");
 let postcss = require("postcss");
 let autoprefixer = require("autoprefixer");
 const SassString = require("node-sass").types.String;

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "faucet-pipeline-sass",
-  "version": "0.1.0",
-  "description": "Sass Asset Pipeline",
-  "main": "lib/index.js",
-  "scripts": {
-    "test": "eslint --cache lib samples && echo ✓"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/faucet-pipeline/faucet-pipeline-sass.git"
-  },
-  "author": "Lucas Dohmen <lucas@dohmen.io> (https://lucas.dohmen.io/)",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/faucet-pipeline/faucet-pipeline-sass/issues"
-  },
-  "homepage": "https://github.com/faucet-pipeline/faucet-pipeline-sass#readme",
-  "dependencies": {
-    "autoprefixer": "^7.1.2",
-    "faucet-pipeline": "^0.9.1",
-    "faucet-pipeline-util": "^0.8.0",
-    "mkdirp": "^0.5.1",
-    "node-sass": "^4.5.3"
-  },
-  "devDependencies": {
-    "eslint": "^4.1.1",
-    "eslint-config-fnd": "^1.1.1"
-  }
+	"name": "faucet-pipeline-sass",
+	"version": "0.1.0",
+	"description": "Sass Asset Pipeline",
+	"main": "lib/index.js",
+	"scripts": {
+		"test": "eslint --cache lib samples && echo ✓"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/faucet-pipeline/faucet-pipeline-sass.git"
+	},
+	"author": "Lucas Dohmen <lucas@dohmen.io> (https://lucas.dohmen.io/)",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/faucet-pipeline/faucet-pipeline-sass/issues"
+	},
+	"homepage": "https://github.com/faucet-pipeline/faucet-pipeline-sass#readme",
+	"dependencies": {
+		"autoprefixer": "^7.1.2",
+		"faucet-pipeline": "^0.9.1",
+		"faucet-pipeline-util": "^0.8.0",
+		"mkdirp": "^0.5.1",
+		"node-sass": "^4.5.3"
+	},
+	"devDependencies": {
+		"eslint": "^4.1.1",
+		"eslint-config-fnd": "^1.1.1"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
-  "name": "faucet-pipeline-css",
+  "name": "faucet-pipeline-sass",
   "version": "0.1.0",
-  "description": "CSS Asset Pipeline",
+  "description": "Sass Asset Pipeline",
   "main": "lib/index.js",
   "scripts": {
     "test": "eslint --cache lib samples && echo ✓"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/faucet-pipeline/faucet-pipeline-css.git"
+    "url": "git+https://github.com/faucet-pipeline/faucet-pipeline-sass.git"
   },
   "author": "Lucas Dohmen <lucas@dohmen.io> (https://lucas.dohmen.io/)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/faucet-pipeline/faucet-pipeline-css/issues"
+    "url": "https://github.com/faucet-pipeline/faucet-pipeline-sass/issues"
   },
-  "homepage": "https://github.com/faucet-pipeline/faucet-pipeline-css#readme",
+  "homepage": "https://github.com/faucet-pipeline/faucet-pipeline-sass#readme",
   "dependencies": {
     "autoprefixer": "^7.1.2",
-    "faucet-pipeline-cli": "^0.8.1",
+    "faucet-pipeline": "^0.9.1",
+    "faucet-pipeline-util": "^0.8.0",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.5.3"
   },

--- a/samples/faucet.js
+++ b/samples/faucet.js
@@ -1,5 +1,5 @@
 module.exports = {
-	css: {
+	sass: {
 		targetDir: "./output",
 		manifest: {
 			file: "./css.json",


### PR DESCRIPTION
* Renaming this Project to `faucet-pipeline-sass`, because it handles Sass. There could be other pipelines that take in PostCSS, stylus or less, but still put out CSS.
* Adjust to @FND style again