### PR TITLE
Add source context to reporting

### DIFF
--- a/lib/build-bundler.js
+++ b/lib/build-bundler.js
@@ -4,6 +4,7 @@ let postcss = require("postcss");
 let autoprefixer = require("autoprefixer");
 let SassString = require("node-sass").types.String;
 let SassError = require("node-sass").types.Error;
+let { repr } = require("faucet-pipeline/lib/util");
 
 // Create a bundler for a specific bundle
 module.exports = config => {
@@ -65,13 +66,14 @@ function buildSassRenderer(options) {
 	return _ => renderSass(sassOptions);
 }
 
-function buildAutoprefixer({ browsers, inputFileName, sourcemaps }) {
+function buildAutoprefixer({ browsers, inputFileName, assetManager, sourcemaps }) {
 	if(!browsers) {
 		return result => result;
 	}
 
 	if(browsers.length) {
-		console.error("compiling Sass for", browsers.join(", "));
+		let filepath = path.relative(assetManager.referenceDir, inputFileName);
+		console.error(`compiling Sass ${repr(filepath)} for ${browsers.join(", ")}`);
 	}
 	let processor = postcss([
 		autoprefixer({ browsers, map: sourcemaps })


### PR DESCRIPTION
> otherwise if there are multiple bundles, it's not clear which one the
> output is referring to

I'm not sure whether this is the best way to phrase it though. Also, there might be other instances where we might wanna do something similar.