### PR TITLE
Improve error reporting for mandatory configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 let buildBundler = require("./build-bundler");
+let { abort, repr } = require("faucet-pipeline-core/lib/util");
 
 module.exports = (pluginConfig, assetManager, options) => {
 	let { browsers, compact, sourcemaps, watcher } = options;
@@ -16,17 +17,19 @@ module.exports = (pluginConfig, assetManager, options) => {
 };
 
 function buildConfig(pluginConfig, assetManager, { browsers, compact, sourcemaps }) {
-	return pluginConfig.map(bundleConfig => {
-		let inputFileName = assetManager.resolvePath(bundleConfig.source);
-		let target = assetManager.resolvePath(bundleConfig.target, {
-			enforceRelative: true
-		});
+	return pluginConfig.map(({ source, target, browserslist, fingerprint }) => {
+		if(!source || !target) {
+			let setting = source ? "target" : "source";
+			abort(`ERROR: missing ${repr(setting, false)} configuration in Sass bundle`);
+		}
+
+		let inputFileName = assetManager.resolvePath(source);
+		target = assetManager.resolvePath(target, { enforceRelative: true });
 
 		let outputStyle = compact ? "compact" : "nested";
 		let includePaths = [ assetManager.packagesDir ];
 
 		let selectedBrowsers;
-		let { browserslist } = bundleConfig;
 		if(browserslist === false) {
 			selectedBrowsers = null;
 		} else if(browserslist) {
@@ -41,7 +44,7 @@ function buildConfig(pluginConfig, assetManager, { browsers, compact, sourcemaps
 			browsers: selectedBrowsers,
 			outputStyle,
 			assetManager,
-			fingerprint: bundleConfig.fingerprint,
+			fingerprint,
 			sourcemaps,
 			target
 		};


### PR DESCRIPTION
cf. https://github.com/faucet-pipeline/faucet-pipeline-js/commit/07c9e9fcafa7921bb1c90ed3e7cdf64d611a9c3f

this avoids confronting users with an exception that they can't make sense of ("Cannot read property 'substr' of undefined")