### PR TITLE
Switch from node-sass to sass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {
 		browsers = browsers.defaults;
 	}
 
-	let renderSass = makeSassRenderer(source, assetManager, sourcemaps, compact);
+	let renderSass = makeSassRenderer(source, target, assetManager, sourcemaps, compact);
 	let autoprefix = makeAutoprefixer(source, assetManager, sourcemaps, browsers);
 
 	let previouslyIncludedFiles;
@@ -71,7 +71,7 @@ function previouslyIncluded(filepaths, previouslyIncludedFiles) {
 
 function errorOutput(message) {
 	return `body:before {
-	content: "\\26a0  CSS Error: ${message.replace(/"/g, "'")}";
+	content: "\\26a0  CSS Error: ${message.replace(/"/g, "'").replace(/\s+/g, " ")}";
 	font-weight: bold;
 	display: block;
 	border: 5px solid red;

--- a/lib/make-sass-renderer.js
+++ b/lib/make-sass-renderer.js
@@ -1,22 +1,23 @@
-let sass = require("node-sass");
-let SassString = require("node-sass").types.String;
-let SassError = require("node-sass").types.Error;
+let sass = require("sass");
 
-module.exports = function(inputFileName, assetManager, sourcemaps, compact) {
+module.exports = function(inputFileName, target, assetManager, sourcemaps, compact) {
 	let sassOptions = {
 		file: inputFileName,
 		outputStyle: compact ? "compressed" : "expanded",
 		includePaths: [ assetManager.packagesDir ],
+		sourceMap: sourcemaps,
 		sourceMapEmbed: sourcemaps,
+		outFile: target,
 		functions: {
 			"asset-url($assetName)": assetName => {
-				let mappedAssetName = assetManager.manifest.get(assetName.getValue());
+				let name = assetName.getValue();
+				let mappedAssetName = assetManager.manifest.get(name);
 
-				if(mappedAssetName) {
-					return new SassString(`url("${mappedAssetName}")`);
-				} else {
-					return new SassError(`${assetName.getValue()} could not be found`);
-				}
+				/* eslint-disable indent */
+				return mappedAssetName ?
+						new sass.types.String(`url("${mappedAssetName}")`) :
+						new sass.types.Error(`${name} could not be found`);
+				/* eslint-enable indent */
 			}
 		}
 	};
@@ -31,8 +32,14 @@ function renderSass(options) {
 			if(err) {
 				reject(err);
 			} else {
+				result.css = fixEOF(result.css);
 				resolve(result);
 			}
 		});
 	});
+}
+
+// every file shall end with a newline. sass doesn't seem to care.
+function fixEOF(buf) {
+	return Buffer.concat([buf, Buffer.from("\n")]);
 }

--- a/lib/make-sass-renderer.js
+++ b/lib/make-sass-renderer.js
@@ -28,14 +28,14 @@ module.exports = function(inputFileName, target, assetManager, sourcemaps, compa
 // promisified version of sass.render
 function renderSass(options) {
 	return new Promise((resolve, reject) => {
-		sass.render(options, (err, result) => {
-			if(err) {
-				reject(err);
-			} else {
-				result.css = fixEOF(result.css);
-				resolve(result);
-			}
-		});
+		try {
+			// using synchronous rendering because it is faster
+			let result = sass.renderSync(options);
+			result.css = fixEOF(result.css);
+			resolve(result);
+		} catch(err) {
+			reject(err);
+		}
 	});
 }
 

--- a/lib/make-sass-renderer.js
+++ b/lib/make-sass-renderer.js
@@ -5,7 +5,7 @@ let SassError = require("node-sass").types.Error;
 module.exports = function(inputFileName, assetManager, sourcemaps, compact) {
 	let sassOptions = {
 		file: inputFileName,
-		outputStyle: compact ? "compact" : "nested",
+		outputStyle: compact ? "compressed" : "expanded",
 		includePaths: [ assetManager.packagesDir ],
 		sourceMapEmbed: sourcemaps,
 		functions: {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 	"dependencies": {
 		"autoprefixer": "^9.0.2",
 		"faucet-pipeline-core": "~1.0.0-rc.13",
-		"node-sass": "^4.9.2",
-		"postcss": "^7.0.2"
+		"postcss": "^7.0.2",
+		"sass": "^1.13.0"
 	},
 	"devDependencies": {
 		"eslint-config-fnd": "^1.6.0",

--- a/test/run
+++ b/test/run
@@ -12,6 +12,16 @@ begin "$root/test_basic"
 	assert_missing "./expected.json"
 end
 
+begin "$root/test_import_scss"
+	faucet
+	assert_identical "./dist/bundle.css" "./expected.css"
+end
+
+begin "$root/test_import_css"
+	faucet
+	assert_identical "./dist/bundle.css" "./expected.css"
+end
+
 begin "$root/test_errors"
 	faucet || echo "Crashed successfully"
 	assert_identical "./dist/bundle.css" "./expected.css"
@@ -19,7 +29,7 @@ end
 
 begin "$root/test_fingerprinting"
 	faucet --fingerprint
-	assert_identical "./dist/fingerprint/bundle-0240c59df06ce5a13dfa95cad19eab81.css" "./expected.css"
+	assert_identical "./dist/fingerprint/bundle-5819c88271a78d848df8b3991c74df09.css" "./expected.css"
 	assert_identical "./dist/no-fingerprint/bundle.css" "./expected.css"
 	assert_json "./dist/manifest.json" "./expected.json"
 end
@@ -63,7 +73,7 @@ end
 
 begin "$root/test_static_integration"
 	faucet --fingerprint
-	assert_identical "./dist/bundle-b28171743fab7b46cd98c3de0b5c39a6.css" "./expected.css"
+	assert_identical "./dist/bundle-3166b72ba211e69a0aab5bf612ded7d3.css" "./expected.css"
 	assert_json "./dist/manifest.json" "./expected.json"
 end
 

--- a/test/test_base_uri/expected.css
+++ b/test/test_base_uri/expected.css
@@ -1,2 +1,3 @@
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_basic/expected.css
+++ b/test/test_basic/expected.css
@@ -1,2 +1,3 @@
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_compact/expected.css
+++ b/test/test_compact/expected.css
@@ -1,1 +1,1 @@
-.bla { color: green; }
+.bla{color:green}

--- a/test/test_errors/expected.css
+++ b/test/test_errors/expected.css
@@ -1,5 +1,5 @@
 body:before {
-	content: "\26a0  CSS Error: Invalid CSS after '	color: $color;': expected '}', was ''";
+	content: "\26a0  CSS Error: expected '{'. src/index.scss 6:1 root stylesheet";
 	font-weight: bold;
 	display: block;
 	border: 5px solid red;

--- a/test/test_fingerprinting/expected.css
+++ b/test/test_fingerprinting/expected.css
@@ -1,2 +1,3 @@
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_fingerprinting/expected.json
+++ b/test/test_fingerprinting/expected.json
@@ -1,4 +1,4 @@
 {
-	"dist/fingerprint/bundle.css":"/assets/dist/fingerprint/bundle-0240c59df06ce5a13dfa95cad19eab81.css",
+	"dist/fingerprint/bundle.css":"/assets/dist/fingerprint/bundle-5819c88271a78d848df8b3991c74df09.css",
 	"dist/no-fingerprint/bundle.css":"/assets/dist/no-fingerprint/bundle.css"
 }

--- a/test/test_import_css/expected.css
+++ b/test/test_import_css/expected.css
@@ -1,0 +1,7 @@
+.foo {
+  background: green;
+}
+
+.bar {
+  background: red;
+}

--- a/test/test_import_css/faucet.config.js
+++ b/test/test_import_css/faucet.config.js
@@ -1,0 +1,15 @@
+"use strict";
+let path = require("path");
+
+module.exports = {
+	sass: [{
+		source: "./src/index.scss",
+		target: "./dist/bundle.css"
+	}],
+	plugins: {
+		sass: {
+			plugin: path.resolve("../.."),
+			bucket: "styles"
+		}
+	}
+};

--- a/test/test_import_css/src/index.scss
+++ b/test/test_import_css/src/index.scss
@@ -1,0 +1,5 @@
+@import "./lib";
+
+.bar {
+	background: red;
+}

--- a/test/test_import_css/src/lib.css
+++ b/test/test_import_css/src/lib.css
@@ -1,0 +1,3 @@
+.foo {
+	background: green;
+}

--- a/test/test_import_scss/expected.css
+++ b/test/test_import_scss/expected.css
@@ -1,0 +1,7 @@
+.foo {
+  background: green;
+}
+
+.bar {
+  background: red;
+}

--- a/test/test_import_scss/faucet.config.js
+++ b/test/test_import_scss/faucet.config.js
@@ -1,0 +1,15 @@
+"use strict";
+let path = require("path");
+
+module.exports = {
+	sass: [{
+		source: "./src/index.scss",
+		target: "./dist/bundle.css"
+	}],
+	plugins: {
+		sass: {
+			plugin: path.resolve("../.."),
+			bucket: "styles"
+		}
+	}
+};

--- a/test/test_import_scss/src/index.scss
+++ b/test/test_import_scss/src/index.scss
@@ -1,0 +1,5 @@
+@import "./lib";
+
+.bar {
+	background: red;
+}

--- a/test/test_import_scss/src/lib.scss
+++ b/test/test_import_scss/src/lib.scss
@@ -1,0 +1,3 @@
+.foo {
+	background: green;
+}

--- a/test/test_key_config/expected.css
+++ b/test/test_key_config/expected.css
@@ -1,2 +1,3 @@
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_key_config/expected.json
+++ b/test/test_key_config/expected.json
@@ -1,1 +1,1 @@
-{"bundle.css":"/dist/bundle-0240c59df06ce5a13dfa95cad19eab81.css"}
+{"bundle.css":"/dist/bundle-5819c88271a78d848df8b3991c74df09.css"}

--- a/test/test_multi/expected_bar.css
+++ b/test/test_multi/expected_bar.css
@@ -1,2 +1,3 @@
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_multi/expected_foo.css
+++ b/test/test_multi/expected_foo.css
@@ -1,2 +1,3 @@
 .bla {
-  color: red; }
+  color: red;
+}

--- a/test/test_no_prefix/expected.css
+++ b/test/test_no_prefix/expected.css
@@ -1,2 +1,3 @@
 .bla {
-  display: flex; }
+  display: flex;
+}

--- a/test/test_prefix/expected.css
+++ b/test/test_prefix/expected.css
@@ -1,3 +1,4 @@
 .bla {
   display: -ms-flexbox;
-  display: flex; }
+  display: flex;
+}

--- a/test/test_prefix_with_different_browserslist/expected.css
+++ b/test/test_prefix_with_different_browserslist/expected.css
@@ -1,3 +1,4 @@
 .bla {
   display: -ms-flexbox;
-  display: flex; }
+  display: flex;
+}

--- a/test/test_sourcemap/expected.css
+++ b/test/test_sourcemap/expected.css
@@ -6,3 +6,4 @@
 .bla {
   color: green;
 }
+

--- a/test/test_sourcemap/expected.css
+++ b/test/test_sourcemap/expected.css
@@ -1,6 +1,8 @@
 .blubb {
   display: -ms-flexbox;
-  display: flex; }
+  display: flex;
+}
 
 .bla {
-  color: green; }
+  color: green;
+}

--- a/test/test_sourcemap/expected.css.map
+++ b/test/test_sourcemap/expected.css.map
@@ -1,5 +1,5 @@
 {
   "version": 3,
   "names": [],
-  "mappings": "AAEA;EACC,qBAAa;EAAb,cAAa;CACb;;AAED;EACC,aAPY;CAQZ"
+  "mappings": "AAEA;EACC,qBAAA;EAAA,cAAA;CADA;;AAID;EACC,aAPO;CAMP"
 }

--- a/test/test_sourcemap/expected.css.map
+++ b/test/test_sourcemap/expected.css.map
@@ -1,5 +1,5 @@
 {
   "version": 3,
   "names": [],
-  "mappings": "AAEA;EACC,qBAAa;EAAb,cAAa,EACb;;AAED;EACC,aAPY,EAQZ"
+  "mappings": "AAEA;EACC,qBAAa;EAAb,cAAa;CACb;;AAED;EACC,aAPY;CAQZ"
 }

--- a/test/test_static_integration/expected.css
+++ b/test/test_static_integration/expected.css
@@ -1,3 +1,4 @@
 .bla {
   background: url("/assets/dist/spacer-d89746888da2d9510b64a9f031eaecd5.gif");
-  color: green; }
+  color: green;
+}

--- a/test/test_static_integration/expected.json
+++ b/test/test_static_integration/expected.json
@@ -1,1 +1,1 @@
-{"dist/spacer.gif":"/assets/dist/spacer-d89746888da2d9510b64a9f031eaecd5.gif","dist/bundle.css":"/assets/dist/bundle-b28171743fab7b46cd98c3de0b5c39a6.css"}
+{"dist/spacer.gif":"/assets/dist/spacer-d89746888da2d9510b64a9f031eaecd5.gif","dist/bundle.css":"/assets/dist/bundle-3166b72ba211e69a0aab5bf612ded7d3.css"}


### PR DESCRIPTION
In this PR, we switch from node-sass (which is the libsass version) to sass (which is the reference implementation in Dart). Differences:

* Switch to different output formats: The chosen output formats are not supported by sass. We therefore switch from `nested` to `expanded` and from `compact` to `compressed` (@FND will disapprove that last one). This is done in a separate commit to make the diff easier to understand.
* The error messages are a little different
* The sourcemaps need to be configured a little differently (that did cost me a lot of time 😿)
* `sass` doesn't put a newline at the end of the generated buffers. [This is bad](https://robots.thoughtbot.com/no-newline-at-end-of-file), so we fix it. I don't like that we need to do that... I may open a ticket.
* Switching to synchronous compiling, because it is faster. This is still a little slower than libSass, but on the code base I tested it with, it was okay.