### PR TITLE
Fix watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 faucet-pipeline-sass version history
 ==================================
 
+v1.9.1
+------
+
+_2025-02-05_
+
+* Fix watch mode
+* Reduce dev dependencies
+
+
 v1.9.0
 ------
 
 _2025-01-26_
 
 * Maintenance release to update dependencies
-* Internally switched to the new `compile` API
+* Internally switch to the new `compile` API
 
 v1.8.0
 ------

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {
 				then(autoprefix).
 				then(result => {
 					previouslyIncludedFiles = (result.loadedUrls ?? []).
-						map(filepath => path.normalize(filepath.toString()));
+						map(filepath => filepath.pathname);
 
 					let options = {};
 					if(fingerprint !== undefined) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-sass",
-	"version": "1.9.0",
+	"version": "1.9.1",
 	"description": "Sass for faucet-pipeline",
 	"main": "lib/index.js",
 	"scripts": {


### PR DESCRIPTION
I just learned that the new release of faucet-pipeline-sass breaks watch mode (for the SCSS part only, of course).

What went wrong:
Before the last release, this is how we found `previouslyIncludedFiles`:

```js
previouslyIncludedFiles = result.stats.includedFiles.
  map(filepath => path.normalize(filepath));
```

I needed to change it, as the new Sass renderer doesn't provide `stats` anymore. So I switched it to this:

```js
previouslyIncludedFiles = (result.loadedUrls ?? []).
  map(filepath => path.normalize(filepath.toString()));
```

`loadedUrls` is actually a list of `URL`s now (or, annoyingly, null, which is where the `??` comes from). So, naively, I put a `toString` on it and moved on. And that's the bug, as this returns something like:

```
'file:/tmp/yunowatch/styles/index.scss'
``` 

And the `file:` is the problem. This will not match the `/tmp/yunowatch/styles/index.scss` core provides us when it notices the file changed. So instead of calling `path.normalize(filepath.toString())` on the URL, I now changed it to: 

```js
filepath.pathname
```

Now, the watch mode works again. [These are the docs for `URL#pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname)

PS: It is super annoying to test if watch mode works... I don't think you can automatically test it. And even testing it by hand is super annoying. 